### PR TITLE
Fix sign-ups

### DIFF
--- a/src/Ideastrike/Controllers/TokenController.cs
+++ b/src/Ideastrike/Controllers/TokenController.cs
@@ -79,7 +79,7 @@ namespace Ideastrike.Controllers
 
             //OM NOM NOM. ALL OF THE COOKIES
             Response.Cookies.Add(cookie);
-            return View();
+            return Redirect("/");
         }
 
         private ActionResult Error(string message)


### PR DESCRIPTION
return View() on the token login doesn't return anything and causes an error, redirecting back to the / means no error shows up.
